### PR TITLE
Potential fix for code scanning alert no. 11: Binding a socket to all network interfaces

### DIFF
--- a/Proxy.py
+++ b/Proxy.py
@@ -269,7 +269,7 @@ class Proxy:
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 try:
                     # Bind immediately to lock the port
-                    s.bind(("0.0.0.0", port))
+                    s.bind(("127.0.0.1", port))
                     # Ensure the port is usable for TCP connections
                     s.listen(1)
                     s.close()  # Close so the actual proxy server can use it


### PR DESCRIPTION
Potential fix for [https://github.com/Frank1o3/Python-Proxy/security/code-scanning/11](https://github.com/Frank1o3/Python-Proxy/security/code-scanning/11)

To fix the issue, we will modify the `__find_available_port` method to bind the socket to `127.0.0.1` instead of `0.0.0.0` when checking for available ports. This ensures that the port-checking process is restricted to the local machine and does not expose the service to external networks. The change will be made on line 272, where the `bind` method is called.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
